### PR TITLE
Pride comes before a fool.

### DIFF
--- a/system-tests/helpers/test_utils.ts
+++ b/system-tests/helpers/test_utils.ts
@@ -323,6 +323,38 @@ export async function getBrowserPage(
     return voteSummary;
   });
 
+  addBrowserFunction(
+    "assertThatTheVotingButtonsAreDifferentColors",
+    async () => {
+      const document = { querySelectorAll: (selector: string) => [selector] };
+      const window = {
+        getComputedStyle: (_button: string) => ({
+          backgroundColor: "this-is-just-to-keep-the-typechecker-happy",
+        }),
+      };
+      await browserFns.refreshPageWhenJsDisabled();
+      verboseLog("Checking that the voting buttons are different colors");
+      const buttonColors = await page.evaluate(() => {
+        const buttons = Array.from(document.querySelectorAll("button"));
+        return buttons.map((button) => {
+          return window.getComputedStyle(button).backgroundColor;
+        });
+      });
+
+      verboseLog("Button colors:", buttonColors);
+
+      const uniqueColors = new Set(buttonColors);
+      if (uniqueColors.size !== 3) {
+        throw new Error(
+          `Expected 3 unique colours, got [${uniqueColors.size}], voting buttons must have the same color - [${
+            buttonColors.join(", ")
+          }]`,
+        );
+      }
+      verboseLog("Voting buttons have different colors");
+    },
+  );
+
   if (parsedUrl.pathname) {
     await browserFns.visit(parsedUrl.pathname);
   }

--- a/system-tests/rooms.spec.ts
+++ b/system-tests/rooms.spec.ts
@@ -157,6 +157,12 @@ describe("Rooms", () => {
       await allBrowsersPromise;
 
       await Promise.all([
+        firstGuestBrowser.assertThatTheVotingButtonsAreDifferentColors(),
+        secondGuestBrowser.assertThatTheVotingButtonsAreDifferentColors(),
+        thirdGuestBrowser.assertThatTheVotingButtonsAreDifferentColors(),
+        fourthGuestBrowser.assertThatTheVotingButtonsAreDifferentColors(),
+      ]);
+      await Promise.all([
         firstGuestBrowser.clickButton("For"),
         secondGuestBrowser.clickButton("Against"),
         thirdGuestBrowser.clickButton("Abstain"),

--- a/web-server/tailwind.config.js
+++ b/web-server/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
-    "*.{tsx,ts,jsx,js}", // Simplified glob pattern
+    "**/*.{tsx,ts,jsx,js}", // Simplified glob pattern
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
I don't (yet) have any visual regression tests, but I relied on the tests.  The last refactor I did knocked out all the styles and I didn't look at the site visually until it was auto-deployed to production.

I've added a test to assert that the voting buttons are different colours to eachother - that feels like the most basic assertion that the styles are being included without having to name a specific colour that should be present.  I could also assert that the title is larger than the main text etc.

We don't have any users right now so it's not the worst thing but I'm a bit annoyed that I was so excited about the big refactor and missed this.

The only change to the implementation is:

```
"**/*.{tsx,ts,jsx,js}"
```

instead of:

```
"*.{tsx,ts,jsx,js}",
```

The rest is a test to protect against regression.