### PR TITLE
Change content priority on host screen

### DIFF
--- a/lib/components/RoomDisplayForHost.tsx
+++ b/lib/components/RoomDisplayForHost.tsx
@@ -21,6 +21,10 @@ export function RoomDisplayForHost(
 ) {
   return (
     <>
+      {isOpen
+        ? getVoteControls(roomUrlName, currentVote, stats)
+        : getOpenVotingForm(roomUrlName)}
+      <PreviousVoteSummaryList voteSummary={previousVoteSummary} />
       <div className={largeContainer}>
         <p className={normalTextClasses}>
           The room is currently {isOpen
@@ -34,10 +38,6 @@ export function RoomDisplayForHost(
           <a className={normalLinkClasses} href={roomUrl}>{roomUrl}</a>
         </p>
       </div>
-      {isOpen
-        ? getVoteControls(roomUrlName, currentVote, stats)
-        : getOpenVotingForm(roomUrlName)}
-      <PreviousVoteSummaryList voteSummary={previousVoteSummary} />
     </>
   );
 }


### PR DESCRIPTION
The content was previously arranged in the order it was created in, the most important content ended up being visually below less important content.  Swapping the order should make it more friendly to new users.