### PR TITLE
Use short URLs for rooms

### DIFF
--- a/lib/db-functions/database-access.ts
+++ b/lib/db-functions/database-access.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import { Database } from "jsr:@db/sqlite";
 import { pathJoin, projectDir } from "../paths.ts";
-import { randomUUID } from "node:crypto";
 import { User } from "../AuthHandler.ts";
 
 let db: Database | undefined;
@@ -72,8 +71,28 @@ export function getSession(key: string): string | null {
   return row.username;
 }
 
+// inspired by https://medium.com/deno-the-complete-reference/a-url-shortener-service-in-deno-e2bc5a874911
+function generateRoomUrlName(targetLength = 8) {
+  const arr = new Uint8Array(targetLength / 2);
+  crypto.getRandomValues(arr);
+  const toHex = (d: number) => d.toString(16).padStart(2, "0");
+  return Array.from(arr, toHex).join("");
+}
+
+function roomUrlNameAlreadyExists(roomId: string) {
+  return roomNameByUrlName(roomId) !== null;
+}
+
+function generateUniqueRoomUrlName() {
+  let roomId: string;
+  do {
+    roomId = generateRoomUrlName();
+  } while (roomUrlNameAlreadyExists(roomId));
+  return roomId;
+}
+
 export function createRoom(roomName: string, ownerUsername: string) {
-  const urlName = randomUUID();
+  const urlName = generateUniqueRoomUrlName();
   const db = getDb();
   db.prepare(
     `

--- a/scripts/dev-command.ts
+++ b/scripts/dev-command.ts
@@ -159,7 +159,7 @@ function runDenoCommand(command: string) {
   let manuallyStopped = false;
   const cmd = new Deno.Command("deno", {
     env: getEnvToPassThrough(command),
-    args: ["task", command],
+    args: ["task", command, "--trace-leaks"],
     stdout: "inherit",
     stderr: "inherit",
   });

--- a/system-tests/helpers/test_utils.ts
+++ b/system-tests/helpers/test_utils.ts
@@ -15,7 +15,7 @@ afterAll(async () => {
 
 setTimeout(() => {
   throw new Error("Test took too long!");
-}, 15_000 + (Number(Deno.env.get("VOI__DELAY_BEFORE_CLOSING_BROWSER")) || 0));
+}, 20_000 + (Number(Deno.env.get("VOI__DELAY_BEFORE_CLOSING_BROWSER")) || 0));
 
 type CleanupFn = () => Promise<void>;
 


### PR DESCRIPTION
There was a request for meaningful, readable room URLs, I'm cautious about that and want to take more time to get it right. The URLs have been unnecessarily long.  This update just makes them shorter, still random, still not within the user's control.

Room URL Names will now be 8 alphanumeric chars - all lower case.

(an improvement based on https://github.com/ancientrose-uk/vote-on-it/issues/15)

(also tracing memory leaks in tests while running them when files change)